### PR TITLE
Feature/#9/common response setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     // lombok
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/devocean/tickit/global/api/ApiResponse.java
+++ b/src/main/java/devocean/tickit/global/api/ApiResponse.java
@@ -1,0 +1,25 @@
+package devocean.tickit.global.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.Nullable;
+
+public record ApiResponse<T>(
+        @JsonIgnore HttpStatus httpStatus,
+        boolean success,
+        @Nullable T data,
+        @Nullable ExceptionDto error
+        ) {
+
+        public static <T> ApiResponse<T> ok(@Nullable final T data) {
+                return new ApiResponse<>(HttpStatus.OK, true, data, null);
+        }
+
+        public static <T> ApiResponse<T> created(@Nullable final T data) {
+                return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
+        }
+
+        public static <T> ApiResponse<T> failed(final CustomException e) {
+                return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode()));
+        }
+}

--- a/src/main/java/devocean/tickit/global/api/ApiResponse.java
+++ b/src/main/java/devocean/tickit/global/api/ApiResponse.java
@@ -19,7 +19,7 @@ public record ApiResponse<T>(
                 return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
         }
 
-        public static <T> ApiResponse<T> failed(final CustomException e) {
-                return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode()));
+        public static <T> ApiResponse<T> failed(final ErrorCode errorCode) {
+                return new ApiResponse<>(errorCode.getHttpStatus(), false, null, ExceptionDto.of(errorCode));
         }
 }

--- a/src/main/java/devocean/tickit/global/api/CustomException.java
+++ b/src/main/java/devocean/tickit/global/api/CustomException.java
@@ -1,0 +1,16 @@
+package devocean.tickit.global.api;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException { // exception custom을 위한 class
+
+    private final ErrorCode errorCode;
+
+    // 로그 필요 시 error message 참고하면 됨
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+}

--- a/src/main/java/devocean/tickit/global/api/ErrorCode.java
+++ b/src/main/java/devocean/tickit/global/api/ErrorCode.java
@@ -1,0 +1,27 @@
+package devocean.tickit.global.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // 000 분류가 필요한 에러
+    // 00
+    UNCUSTOMED_ERROR(00000, HttpStatus.OK, "서버 에러 커스텀이 필요"),
+
+    // 404 Not Found
+    // 00
+    NOT_FOUND(40400, HttpStatus.NOT_FOUND, "존재하지 않음"),
+    NOT_FOUND_END_POINT(40401, HttpStatus.NOT_FOUND, "존재하지 않는 API"),
+
+    // 500 Internal Server Error
+    // 00
+    INTERBAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),
+
+    private final Integer code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/devocean/tickit/global/api/ErrorCode.java
+++ b/src/main/java/devocean/tickit/global/api/ErrorCode.java
@@ -21,6 +21,9 @@ public enum ErrorCode {
     // 00
     INTERBAL_SERVER_ERROR(50000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류"),
 
+
+    ;
+
     private final Integer code;
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/devocean/tickit/global/api/ExceptionDto.java
+++ b/src/main/java/devocean/tickit/global/api/ExceptionDto.java
@@ -1,0 +1,16 @@
+package devocean.tickit.global.api;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ExceptionDto(
+        @NotNull Integer code,
+        @NotNull String message
+) {
+
+    public static ExceptionDto of(ErrorCode errorCode) {
+        return new ExceptionDto(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/devocean/tickit/global/api/GlobalExceptionHandler.java
+++ b/src/main/java/devocean/tickit/global/api/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package devocean.tickit.global.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 존재하지 않는 요청
+    @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ApiResponse<?> handleNoPageFoundException(Exception e) {
+        log.error("GloablExceptionHandler caught NoHandlerFoudException : {}", e.getMessage());
+        return ApiResponse.failed(ErrorCode.NOT_FOUND_END_POINT);
+    }
+
+    // customed error
+    @ExceptionHandler(value = {CustomException.class})
+    public ApiResponse<?> handleCustomException(CustomException e) {
+        log.error("handleCustomException() in GlobalExceptionHandler threw CustomException : {}", e.getMessage());
+        return ApiResponse.failed(e.getErrorCode());
+    }
+
+    // default error
+    @ExceptionHandler(value = {Exception.class})
+    public ApiResponse<?> handleException(Exception e) {
+        log.error("handleException() in GlobalExceptionHandler threw Exception : {}", e.getMessage());
+        e.printStackTrace();
+        return ApiResponse.failed(ErrorCode.INTERBAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/devocean/tickit/global/api/ResponseStatusCodeSetterAdvice.java
+++ b/src/main/java/devocean/tickit/global/api/ResponseStatusCodeSetterAdvice.java
@@ -1,0 +1,32 @@
+package devocean.tickit.global.api;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice // 전체 controller에 대해 적용하기 위한 어노테이션
+public class ResponseStatusCodeSetterAdvice implements ResponseBodyAdvice<ApiResponse<?>> {
+
+    // filter: supports == true일 때만 beforeBodyWrite 작동
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        // 응답값이 ApiResponse일 때만 custom을 실행하도록 check
+        return returnType.getParameterType() == ApiResponse.class;
+    }
+
+    // controller return 전 response filtering
+    @Override
+    public ApiResponse<?> beforeBodyWrite(ApiResponse body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        if (returnType.getParameterType() == ApiResponse.class) {
+            // set header status code
+            HttpStatus status = body.httpStatus();
+            response.setStatusCode(status);
+        }
+
+        return body;
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 공통 응답을 위한 dto 및 관련 enum 생성

---

## ✏️ 관련 이슈

- Related to : #9 

---

## 🎸 기타 사항 or 추가 코멘트

- 공통 응답 DTO가 없어서 작업이 어려워 그냥 만들었습니다.
- 규격화된 apiResponse는 다음의 형식을 가집니다.
```json
// success
{
  "success": true,
  "data": {{contents}},
  "error": null
}

// error
{
  "success": false,
  "data": null,
  "error": {
    "code": 40401, // tickit 자체 코드, api 명세에 정의
    "message": "존재하지 않는 API"
  }
}